### PR TITLE
Refactor Block Creation for Immutable State Management

### DIFF
--- a/src/generator/__tests__/code-generation.test.ts
+++ b/src/generator/__tests__/code-generation.test.ts
@@ -33,36 +33,62 @@ describe("Code Generation", () => {
       parameters: [{ name: "counter", type: "number" }],
     };
 
-    // Create a shared state object
-    const state: CodeGeneratorState = {
+    // Create initial state
+    let state: CodeGeneratorState = {
       blocks: [],
       variables: [{ name: "counter", type: "number", index: 0 }],
       isAsync: false,
     };
 
     // Create blocks
-    const blocks: CodeBlock[] = [
-      createWhileBlock(
-        "counter < 10",
-        [
-          createFunctionCallBlock(updateCounterInfo, state),
-          createFunctionCallBlock(checkConditionInfo, state),
-          createIfBlock(
-            "checkcondition",
-            [createFunctionCallBlock(processEvenInfo, state)],
-            state,
-            undefined,
-            {
-              blocks: [createFunctionCallBlock(processOddInfo, state)],
-            }
-          ),
-        ],
-        state
-      ),
-    ];
+    let whileLoopBlocks: CodeBlock[] = [];
+
+    // Update counter
+    const { block: updateCounterBlock, state: state1 } =
+      createFunctionCallBlock(updateCounterInfo, state);
+    whileLoopBlocks.push(updateCounterBlock);
+    state = state1;
+
+    // Check condition
+    const { block: checkConditionBlock, state: state2 } =
+      createFunctionCallBlock(checkConditionInfo, state);
+    whileLoopBlocks.push(checkConditionBlock);
+    state = state2;
+
+    // Process even
+    const { block: processEvenBlock, state: state3 } = createFunctionCallBlock(
+      processEvenInfo,
+      state
+    );
+    state = state3;
+
+    // Process odd
+    const { block: processOddBlock, state: state4 } = createFunctionCallBlock(
+      processOddInfo,
+      state
+    );
+    state = state4;
+
+    // Create if block
+    const { block: ifBlock, state: state5 } = createIfBlock(
+      "checkcondition",
+      [processEvenBlock],
+      state,
+      undefined,
+      { blocks: [processOddBlock] }
+    );
+    whileLoopBlocks.push(ifBlock);
+    state = state5;
+
+    // Create while block
+    const { block: whileBlock, state: finalState } = createWhileBlock(
+      "counter < 10",
+      whileLoopBlocks,
+      state
+    );
 
     // Generate code
-    const generatedCode = generateCode(blocks);
+    const generatedCode = generateCode([whileBlock]);
 
     // Expected code (formatted for readability)
     const expectedCode = `

--- a/src/generator/__tests__/function-call.test.ts
+++ b/src/generator/__tests__/function-call.test.ts
@@ -23,16 +23,24 @@ describe("Function Call Block Generator", () => {
   });
 
   test("generates function call block successfully", () => {
-    const result = createFunctionCallBlock(functionInfo, initialState);
+    const { block, state } = createFunctionCallBlock(
+      functionInfo,
+      initialState
+    );
 
-    expect(result).toBeDefined();
-    expect(result.blockType).toBe("functionCall");
-    expect(result.functionInfo).toEqual(functionInfo);
-    expect(result.isAsync).toBe(false);
-    expect(result.index).toBe(0);
-    expect(result.returnVariable).toBeDefined();
-    expect(result.returnVariable?.name).toBe("testfunction");
-    expect(result.returnVariable?.type).toBe("string");
+    expect(block).toBeDefined();
+    expect(block.blockType).toBe("functionCall");
+    expect(block.functionInfo).toEqual(functionInfo);
+    expect(block.isAsync).toBe(false);
+    expect(block.index).toBe(0);
+    expect(block.returnVariable).toBeDefined();
+    expect(block.returnVariable?.name).toBe("testfunction");
+    expect(block.returnVariable?.type).toBe("string");
+
+    expect(state.blocks).toHaveLength(1);
+    expect(state.blocks[0]).toBe(block);
+    expect(state.variables).toHaveLength(1);
+    expect(state.variables[0]).toEqual(block.returnVariable);
   });
 
   test("generates function call block with parameters based on state variables", () => {
@@ -44,21 +52,14 @@ describe("Function Call Block Generator", () => {
       ],
     };
 
-    const result = createFunctionCallBlock(functionInfo, stateWithVariables);
+    const { block, state } = createFunctionCallBlock(
+      functionInfo,
+      stateWithVariables
+    );
 
-    expect(result.parameters).toEqual(functionInfo.parameters);
-    // The actual parameter matching would happen in createFunctionCall,
-    // which is not directly tested here. You might want to add a separate
-    // test for that function if it's exported.
-  });
-
-  test("updates state correctly after creating function call block", () => {
-    const result = createFunctionCallBlock(functionInfo, initialState);
-
-    expect(initialState.blocks.length).toBe(1);
-    expect(initialState.blocks[0]).toEqual(result);
-    expect(initialState.variables.length).toBe(1);
-    expect(initialState.variables[0]).toEqual(result.returnVariable);
+    expect(block.parameters).toEqual(functionInfo.parameters);
+    expect(state.variables).toHaveLength(3); // 2 existing + 1 new
+    expect(state.variables[2]).toEqual(block.returnVariable);
   });
 
   test("generates async function call block for Promise return type", () => {
@@ -67,10 +68,14 @@ describe("Function Call Block Generator", () => {
       returnType: "Promise<string>",
     };
 
-    const result = createFunctionCallBlock(asyncFunctionInfo, initialState);
+    const { block, state } = createFunctionCallBlock(
+      asyncFunctionInfo,
+      initialState
+    );
 
-    expect(result.isAsync).toBe(true);
-    expect(result.returnVariable?.type).toBe("string");
+    expect(block.isAsync).toBe(true);
+    expect(block.returnVariable?.type).toBe("string");
+    expect(state.isAsync).toBe(true);
   });
 
   test("generates unique variable names", () => {
@@ -79,11 +84,37 @@ describe("Function Call Block Generator", () => {
       variables: [{ name: "testfunction", type: "string", index: 0 }],
     };
 
-    const result = createFunctionCallBlock(
+    const { block, state } = createFunctionCallBlock(
       functionInfo,
       stateWithExistingVariable
     );
 
-    expect(result.returnVariable?.name).toBe("testfunction2");
+    expect(block.returnVariable?.name).toBe("testfunction2");
+    expect(state.variables).toHaveLength(2);
+    expect(state.variables[1]?.name).toBe("testfunction2");
+  });
+
+  test("creates multiple function call blocks and updates state correctly", () => {
+    let currentState = initialState;
+
+    const { block: block1, state: state1 } = createFunctionCallBlock(
+      functionInfo,
+      currentState
+    );
+    currentState = state1;
+
+    const { block: block2, state: finalState } = createFunctionCallBlock(
+      functionInfo,
+      currentState
+    );
+
+    expect(block1.index).toBe(0);
+    expect(block2.index).toBe(1);
+    expect(finalState.blocks).toHaveLength(2);
+    expect(finalState.blocks[0]).toBe(block1);
+    expect(finalState.blocks[1]).toBe(block2);
+    expect(finalState.variables).toHaveLength(2);
+    expect(finalState.variables[0]).toEqual(block1.returnVariable);
+    expect(finalState.variables[1]).toEqual(block2.returnVariable);
   });
 });

--- a/src/generator/blocks/function-call.ts
+++ b/src/generator/blocks/function-call.ts
@@ -4,7 +4,12 @@ import {
   getUniqueVariableName,
   PROMISE_PREFIX,
 } from "generator/utils";
-import { FunctionCallBlock, FunctionInfo, VariableInfoWithIndex } from "types";
+import {
+  BlockAndState,
+  FunctionCallBlock,
+  FunctionInfo,
+  VariableInfoWithIndex,
+} from "types";
 import { CodeGeneratorState } from "types/generator";
 import {
   AwaitExpression,
@@ -139,7 +144,7 @@ function createVariableDeclaration(
 export function createFunctionCallBlock(
   functionInfo: FunctionInfo,
   state: CodeGeneratorState
-): FunctionCallBlock {
+): BlockAndState<FunctionCallBlock> {
   const index = state.blocks.length;
 
   const variableName = functionInfo.name.toLowerCase();
@@ -159,10 +164,14 @@ export function createFunctionCallBlock(
     blockType: "functionCall",
   };
 
-  state.blocks.push(block);
-  state.variables.push(newVariable);
+  const newState: CodeGeneratorState = {
+    ...state,
+    variables: [...state.variables, newVariable],
+    blocks: [...state.blocks, block],
+    isAsync: state.isAsync || block.isAsync,
+  };
 
-  return block;
+  return { block, state: newState };
 }
 
 /**

--- a/src/generator/blocks/if-block.ts
+++ b/src/generator/blocks/if-block.ts
@@ -1,4 +1,10 @@
-import { CodeBlock, ElseBlock, ElseIfBlock, IfBlock } from "types";
+import {
+  BlockAndState,
+  CodeBlock,
+  ElseBlock,
+  ElseIfBlock,
+  IfBlock,
+} from "types";
 import { CodeGeneratorState } from "types/generator";
 import { factory, Statement } from "typescript";
 import { blockToTypeScript } from "../block-generator";
@@ -84,7 +90,7 @@ export function createIfBlock(
   state: CodeGeneratorState,
   elseIfBlocks?: ElseIfBlock[],
   elseBlock?: ElseBlock
-): IfBlock {
+): BlockAndState<IfBlock> {
   const index = state.blocks.length;
 
   const block: IfBlock = {
@@ -96,7 +102,10 @@ export function createIfBlock(
     blockType: "if",
   };
 
-  state.blocks.push(block);
+  const newState: CodeGeneratorState = {
+    ...state,
+    blocks: [...state.blocks, block],
+  };
 
-  return block;
+  return { block, state: newState };
 }

--- a/src/generator/blocks/while-block.ts
+++ b/src/generator/blocks/while-block.ts
@@ -1,4 +1,4 @@
-import { CodeBlock, WhileLoopBlock } from "../../types/blocks";
+import { BlockAndState, CodeBlock, WhileLoopBlock } from "../../types/blocks";
 import { CodeGeneratorState } from "../../types/generator";
 import { factory, Statement } from "typescript";
 import { blockToTypeScript } from "../block-generator";
@@ -21,7 +21,7 @@ export function createWhileBlock(
   condition: string,
   loopBlocks: CodeBlock[],
   state: CodeGeneratorState
-): WhileLoopBlock {
+): BlockAndState<WhileLoopBlock> {
   const index = state.blocks.length;
 
   const block: WhileLoopBlock = {
@@ -31,7 +31,10 @@ export function createWhileBlock(
     blockType: "while",
   };
 
-  state.blocks.push(block);
+  const newState: CodeGeneratorState = {
+    ...state,
+    blocks: [...state.blocks, block],
+  };
 
-  return block;
+  return { block, state: newState };
 }

--- a/src/types/blocks.ts
+++ b/src/types/blocks.ts
@@ -1,4 +1,5 @@
 import { FunctionInfo, VariableInfo } from "./common";
+import { CodeGeneratorState } from "./generator";
 
 export interface Block {
   index: number;
@@ -39,3 +40,8 @@ export interface WhileLoopBlock extends Block {
 
 // Add more block types as implemented
 export type CodeBlock = FunctionCallBlock | IfBlock | WhileLoopBlock;
+
+export interface BlockAndState<T extends Block> {
+  block: T;
+  state: CodeGeneratorState;
+}


### PR DESCRIPTION
Initially, we wre updating the state reference directly in our block creation functions, but that needs to be changed. It was messy to handle in React and went against immutability principles.

`BlockAndState` interface and refactored functions will return both the created block and the updated state. This way, we keep things immutable and have more control.

Key changes:
- New `BlockAndState` interface
- Block creation functions now return `BlockAndState`
- Updated tests to match the new structure
- Better test coverage for state changes

We could even add stateless versions of these functions! Some features that are dependent on the state (such as grabbing declared variables automatically for parameters) would be disabled for these, though.